### PR TITLE
Fix compatibility with administrate

### DIFF
--- a/lib/administrate/field/acts_as_taggable.rb
+++ b/lib/administrate/field/acts_as_taggable.rb
@@ -21,7 +21,7 @@ module Administrate
         "#{context}_list"
       end
 
-      def self.permitted_attribute(attr)
+      def self.permitted_attribute(attr, **opts)
         context = super.to_s.singularize
         "#{context}_list"
       end


### PR DESCRIPTION
I was previously seeing this error:

```
2021-05-21T21:58:45.428589+00:00 app[web.1]: I, [2021-05-21T21:58:45.428551 #11]  INFO -- : [b531f450-e088-47d7-907a-01219a79eef8] Completed 500 Internal Server Error in 1ms (ActiveRecord: 0.0ms | Allocations: 418)
2021-05-21T21:58:45.429353+00:00 app[web.1]: F, [2021-05-21T21:58:45.429209 #11] FATAL -- : [b531f450-e088-47d7-907a-01219a79eef8]   
2021-05-21T21:58:45.429355+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] ArgumentError (wrong number of arguments (given 2, expected 1)):
2021-05-21T21:58:45.429355+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8]   
2021-05-21T21:58:45.429356+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] administrate-field-acts_as_taggable (0.0.2) lib/administrate/field/acts_as_taggable.rb:24:in `permitted_attribute'
2021-05-21T21:58:45.429357+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] administrate (0.16.0) lib/administrate/base_dashboard.rb:59:in `block in permitted_attributes'
2021-05-21T21:58:45.429357+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] administrate (0.16.0) lib/administrate/base_dashboard.rb:58:in `map'
2021-05-21T21:58:45.429358+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] administrate (0.16.0) lib/administrate/base_dashboard.rb:58:in `permitted_attributes'
2021-05-21T21:58:45.429358+00:00 app[web.1]: [b531f450-e088-47d7-907a-01219a79eef8] administrate (0.16.0) app/controllers/administrate/application_controller.rb:154:in `resource_params'
```